### PR TITLE
Change git-clone-idempotent

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -1,12 +1,23 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-REPO="$1"
-DEFAULT_FOLDER="$(echo "$REPO" | sed 's|.*/||' | sed 's|.git$||')"
-FOLDER="${2:-$DEFAULT_FOLDER}"
+# Output a message when the argument is missing or empty.
+REPO="${1:?Please provide the missing repository argument.}"
+# When the second argument is missing or empty,
+#  replace it with the output of the shell command.
+FOLDER="${2:-$(
+# Remove everything before (and also) the last '/' from REPO.
+  FOLDER="${REPO##*/}"
+# Output the content of FOLDER,
+#  after removing '.git' at the end of the content.
+  printf "${FOLDER%.git}"
+)}"
 
-if [ -d "$FOLDER" ]; then
-  cd "$FOLDER"
-  git pull
-else
-  git clone "$REPO" "$FOLDER"
-fi
+test -e "${FOLDER?}/.git" &&
+# FOLDER contains a .git,
+# replace current process with the following:
+  exec git -C "${FOLDER?}" pull
+
+# FOLDER did not contain .git,
+# so the process has not been replaced,
+# replace it with the following:
+exec git clone "${REPO?}" "${FOLDER?}"


### PR DESCRIPTION
Changes to the "end-state" of executing the command :
- Replaces the shell-process with the git-process (`exec`).
- No longer changes directory to folder (changed end-state).

Added feature/improvement:
- Take into account that the `.git` inside the path/folder could be a file instead of a directory (with `--separate-git-dir`).
- Moved from using `sed` to using posix` subset of variable substitution in a shell substitution.
- Should be/remain compatible with most shells.